### PR TITLE
Fix Reed-Solomon failures after re-locking

### DIFF
--- a/lib/dvb_sync_search_impl.cc
+++ b/lib/dvb_sync_search_impl.cc
@@ -112,6 +112,7 @@ bool dvb_sync_search::process(const unsigned char &input)
 					{
 						if (--cl == 0)
 						{
+							have_output = false;
 							_mode = Unlocked;
 							std::cout << "Sync decoder: Unlocked" << std::endl;
 							fast_forward = 1;	// No longer synced, so read in bit by bit

--- a/python/qa_dvb.py
+++ b/python/qa_dvb.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from gnuradio import gr, gr_unittest, trellis
+from gnuradio import gr, gr_unittest, trellis, digital
 import dvb_swig
 import dvb_interleaver_bb
 import dvb_convolutional_encoder_bb
@@ -407,7 +407,7 @@ class qa_dvb(gr_unittest.TestCase):
 		repack2 = gr.packed_to_unpacked_bb(2, gr.GR_MSB_FIRST)
 		mapper = gr.chunks_to_symbols_bf(constellation, dvb_swig.dimensionality)
 		viterbi = trellis.viterbi_combined_fb(trellis.fsm(dvb_swig.k, dvb_swig.n, dvb_convolutional_encoder_bb.G),
-				dvb_swig.K, -1, -1, dvb_swig.dimensionality, constellation, trellis.TRELLIS_EUCLIDEAN)
+				dvb_swig.K, -1, -1, dvb_swig.dimensionality, constellation, digital.TRELLIS_EUCLIDEAN)
 		pack = gr.unpacked_to_packed_bb(1, gr.GR_MSB_FIRST)
 		dst = gr.vector_sink_b()
 


### PR DESCRIPTION
While demodulating noisy DVB-S signals (Digital Amateur TV from the ISS) I noticed that RS decoding always fails after the first sync unlock/relock cycle. Here is a fix.
